### PR TITLE
Bot | Properly handle ties when using `!queryr`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## Setup
 
-If you are an admin of a discord server and would like to add this bot to your server, you can do so by clicking this [link](https://discord.com/api/oauth2/authorize?client_id=1190188505947701248&permissions=265216&scope=bot). You will need to have the `Manage Server` permission to do this.
+If you are an admin of a discord server and would like to add this bot to your server, you can do so by clicking this [link](https://discord.com/api/oauth2/authorize?client_id=1190188505947701248&permissions=265216&scope=bot).
 
 Once the bot is in your server, you should create a new text channel titled `piu-leaderboard`. This is where the bot will post leaderboard updates and where users can interact with the bot. If you encounter any problems with the bot, please open an issue in this repo.
 
@@ -64,7 +64,7 @@ The following parameters are used in some of the commands above. All parameters 
 
 ![example3a](assets/ex_tracking.png)
 
-#### Then later on...
+#### Later on, when they achieve a new/high score on a chart leaderboard:
 
 ![example3b](assets/ex_track.png)
 
@@ -72,6 +72,4 @@ The following parameters are used in some of the commands above. All parameters 
 
 This project's code is available under the [MIT license](LICENSE).
 
-The icons were downloaded from the official [Pump it Up Phoenix webiste](https://phoenix.piugame.com/) and are property of Andamiro (except for the logo, which was drawn by me 🙂).
-
-You can build upon this project however you wish! Feel free to open an issue or pull request if you have any suggestions or improvements, and I'll try to respond when I have the chance.
+Feel free to open an issue or pull request if you have any suggestions or improvements, and I'll take a look when I get the chance.

--- a/src/bot.py
+++ b/src/bot.py
@@ -122,13 +122,21 @@ async def queryr(ctx: commands.Context, rank: str, chart_id: str):
             rank_range = await get_rank_range(ctx, rank)
             if rank_range and len(rank_range) >= 2:
                 scores = []
-                for i in range(rank_range[0], rank_range[1] + 1):
+                i = rank_range[0]
+                while i <= rank_range[1]:
                     curr_scores = await leaderboard.query_rank(i, chart_id)
                     if curr_scores is None:
                         await ctx.send(QUERY_ERR_MSG)
                         return
                     else:
                         scores.extend(curr_scores)
+
+                        # skip to the next non-tied rank
+                        if len(curr_scores) > 1:
+                            i = curr_scores[0].rank + len(curr_scores)
+                            continue
+
+                    i += 1
 
                 if len(scores) == 0:
                     await ctx.send(f'No scores with rank(s) {rank} on {chart_id}.')


### PR DESCRIPTION
* When a user uses `!queryr` to query a range of ranks that overlaps with a tie, don't output the tied scores more than once


# Testing

* !queryr 2-4 "Acquire Co-opx3" should only output the 2nd place score, followed by the 2 tied 3rd place scores
* !queryr 6-10 "Acquire Co-opx3" should output the 3 tied 5th place scores, followed by 3 scores for 8th-10th