### PR TITLE
Bot | Allow `queryp` to query multiple players at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,4 @@ The following parameters are used in some of the commands above. All parameters 
 
 ## License
 
-This project's code is available under the [MIT license](LICENSE).
-
-Feel free to open an issue or pull request if you have any suggestions or improvements, and I'll take a look when I get the chance.
+This project's code is available under the [MIT license](LICENSE). Feel free to open an issue or pull request if you have any suggestions or improvements, and I'll take a look when I get the chance.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The following parameters are used in some of the commands above. All parameters 
 
 | Parameter | Description |
 | --- | :--- |
-| `player_id` | The player's ID on the leaderboard in the format of `name[#tag]`, where `#tag` is the 4-digit discriminator. If `#tag` is not specified, the bot will search for all players with the name. |
+| `player_id` | The player's ID on the leaderboard in the format of `name[#tag]`, where `#tag` is the 4-digit discriminator. If `#tag` is not specified, the bot will search for all players with the name. To query multiple players at once, use a comma to separate the names ( e.g. `player1,player2` ) |
 | `chart_id` | The ID of the chart to query in the format of `"Song title (S/D/Co-op)(Level)"`. This parameter must be enclosed in quotes. For Co-op chart levels, use x2, x3, etc... If an exact match cannot be found, the bot will provide a list of close matches you can choose from. |
 | `rank` | The rank or range of ranks to query. To query a range, use the format `rank1-rank2`, where `rank1 < rank2`. Ranks must be between 1 and 100.  |
 

--- a/src/bot.py
+++ b/src/bot.py
@@ -91,19 +91,23 @@ async def tracking(ctx: commands.Context):
         await ctx.send(f'Currently tracking the following players: ```{player_names}```')
 
 @bot.command(name='queryp', help='Query a player\'s rank on a level')
-async def queryp(ctx: commands.Context, player_id: str, chart_id: str):
+async def queryp(ctx: commands.Context, player_ids: str, chart_id: str):
     if ctx.channel.name != CHANNEL_NAME:
         return
 
     async with ctx.typing():
         if (new_chart_id := await leaderboard.rescrape(bot, ctx, chart_id)):
             chart_id = new_chart_id
-            scores = await leaderboard.query_score(player_id, chart_id)
+            player_ids = player_ids.split(',')
+            scores = await leaderboard.query_score(player_ids, chart_id)
 
             if scores is None:
                 await ctx.send(QUERY_ERR_MSG)
             elif len(scores) == 0:
-                await ctx.send(f'`{player_id}` is not on the leaderboard for {chart_id}')
+                if len(player_ids) > 1:
+                    await ctx.send(f'No scores for `{', '.join(player_ids)}` on the leaderboard {chart_id}.')
+                else:
+                    await ctx.send(f'`{player_ids[0]}` is not on the leaderboard for {chart_id}')
             else:
                 for score in scores:
                     await ctx.send(embed=await score.embed(prev_score=None, compare=False))

--- a/src/bot_help.py
+++ b/src/bot_help.py
@@ -35,7 +35,7 @@ class LeaderboardHelpCommand(commands.HelpCommand):
 
         pages.append('\nParameters (case-insensitive): ')
         pages.append('\t<chart_id>   "Song title (S/D/Co-op)(Level)"  | must be enclosed in quotes; for Co-op chart levels, use x2, x3, etc...\n'
-                     '\t<player_id>  name[#tag]                       | if #tag is not specified, all scores with a matching name will be returned\n'
+                     '\t<player_id>  name[#tag][,name2[#tag2],...]    | if #tag is not specified, all scores with a matching name will be returned\n'
                      '\t<rank>       rank[-rank]                      | ranks must be between 1 and 100; can optionally specify a range of ranks to query\n')
 
         await self.get_destination().send('```' + '\n'.join(pages) + '```')

--- a/src/leaderboard.py
+++ b/src/leaderboard.py
@@ -131,19 +131,26 @@ class Leaderboard:
         """
         return process.extractBests(chart_id, self.charts.keys(), score_cutoff=60, limit=10)
 
-    async def query_score(self, player_id: str, chart_id: str) -> List[Score]:
+    async def query_score(self, player_ids: List[str], chart_id: str) -> List[Score]:
         """ Query a player's score on a level.
-        @param player_id: the player's ID, in the format of name[#tag]; If [#tag] is not specified, all players with the same name will be queried
+        @param player_ids: the player IDs, in the format of name[#tag]; If [#tag] is not specified, all players with the same name will be queried
         @param chart_id: the level's ID
         @return: list(Score) of all matching players' scores on the given level
         """
         chart_id = chart_id.lower()
 
         if chart_id in self.scores:
-            if '#' in player_id:
-                return [value for key, value in self.scores[chart_id].items() if player_id.upper() == key]
-            else:
-                return [value for key, value in self.scores[chart_id].items() if player_id.upper() == key.split('#')[0]]
+            scores = []
+            for player_id in player_ids:
+                if '#' in player_id:
+                    scores.extend([value for key, value in self.scores[chart_id].items() if player_id.upper() == key])
+                else:
+                    scores.extend([value for key, value in self.scores[chart_id].items() if player_id.upper() == key.split('#')[0]])
+
+            # sort scores by rank
+            scores.sort(key=lambda score: score.rank)
+
+            return scores
 
         return None
 


### PR DESCRIPTION
* Allow users to use `queryp` with multiple player names, separated by commas
* 
* Resulting scores should be sorted by rank
* Updated readme/help command descriptions

# Testing
* `!queryp fefemz,rss "etude op 10-4 d25"` should return both players' scores