### PR TITLE
Leaderboard | Split updates by chart mode

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -176,7 +176,7 @@ async def get_rank_range(ctx: commands.Context, rank: str) -> List[int]:
 
     return rank_range
 
-@tasks.loop(minutes=60)
+@tasks.loop(minutes=20)
 async def update_leaderboard():
     logger.info('Updating leaderboards')
     await leaderboard.update_all()


### PR DESCRIPTION
* Instead of updating all chart leaderboards every 60 minutes, update modes separately every 20 minutes
* May prevent any `discord.py` timeout-related issues / reduce overall number of requests at once