### PR TITLE
Fix player tracking when no `#tag` is provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ The following parameters are used in some of the commands above. All parameters 
 
 | Parameter | Description |
 | --- | :--- |
-| `player_id` | The player's ID on the leaderboard in the format of `name[#tag]`, where `#tag` is the 4-digit discriminator. For `!queryp` commands, if `#tag` is not specified, the bot will search for all players with the name. To query multiple players at once, use a comma to separate the names ( e.g. `player1,player2` ). When using the `!track` command, the `#tag` should be specified |
+| `player_id` | The player's ID on the leaderboard in the format of `name[#tag]`, where `#tag` is the 4-digit discriminator. If `#tag` is not specified, the bot will search for/track all players with the name. To query multiple players at once, use a comma to separate the names ( e.g. `player1,player2` ) |
 | `chart_id` | The ID of the chart to query in the format of `"Song title (S/D/Co-op)(Level)"`. This parameter must be enclosed in quotes. For Co-op chart levels, use x2, x3, etc... If an exact match cannot be found, the bot will provide a list of close matches you can choose from. |
-| `rank` | The rank or range of ranks to query. To query a range, use the format `rank1-rank2`, where `rank1 < rank2`. Rank(s) must be between 1 and 100.  |
+| `rank` | The rank or range of ranks to query. To query a range, use the format `rank1-rank2`, where `rank1 < rank2`. Ranks must be between 1 and 100.  |
 
 ## Examples
 

--- a/src/leaderboard.py
+++ b/src/leaderboard.py
@@ -205,6 +205,7 @@ class Leaderboard:
                 for player in players:
                     if new_score.player == player or ('#' not in player and new_score.player.split('#')[0] == player):
                         updates.append((new_score, prev_score))
+                        break
 
         return updates
 

--- a/src/leaderboard.py
+++ b/src/leaderboard.py
@@ -201,8 +201,10 @@ class Leaderboard:
         """
         updates = []
         for (new_score, prev_score) in self.score_updates:
-            if new_score is not None and new_score.player in players:
-                updates.append((new_score, prev_score))
+            if new_score is not None:
+                for player in players:
+                    if new_score.player == player or ('#' not in player and new_score.player.split('#')[0] == player):
+                        updates.append((new_score, prev_score))
 
         return updates
 


### PR DESCRIPTION
* Updated `get_score_updates()` to include updates if player name with no tag being tracked has a match
* Expected behavior: 
  * `!track playerwithnotag` should track leaderboard updates for any player with the name `playerwithnotag` regardless of their 4-digit tag `#XXXX`