### PR TITLE
Bot | Save pumbility after updating, not after querying

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -216,6 +216,7 @@ async def update_leaderboard():
 async def update_pumbility():
     logger.info('Updating Pumbility leaderboard')
     await leaderboard.update_pumbility()
+    await leaderboard.save_pumbility_leaderboard()
     logger.info('Pumbility leaderboard updated')
 
     for guild in bot.guilds:

--- a/src/leaderboard.py
+++ b/src/leaderboard.py
@@ -181,7 +181,6 @@ class Leaderboard:
         @param player_ids: the player IDs, in the format of name[#tag]; If [#tag] is not specified, all players with the same name will be queried
         @return: list(Pumbility) of all matching players' Pumbility rankings
         """
-        await self.save_pumbility_leaderboard()
         pumbilities = []
 
         for player_id in player_ids:


### PR DESCRIPTION
* Changed bot so that it saves pumbility data after each update, instead of during a pumbility query